### PR TITLE
Correct fetch for `rgb.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - Online table of colors [https://jonasjacek.github.io/colors/](https://jonasjacek.github.io/colors/)
 - XOrg colors [https://github.com/freedesktop/xorg-rgb/blob/master/rgb.txt](https://github.com/freedesktop/xorg-rgb/blob/master/rgb.txt)
-- Vim colors [https://github.com/vim/vim/blob/master/runtime/rgb.txt](https://github.com/vim/vim/blob/master/runtime/rgb.txt)
+- Vim colors <https://github.com/vim/vim/blob/e30d10253f~/runtime/rgb.txt>
 
 ## Any contributions
 

--- a/build-colors/Makefile
+++ b/build-colors/Makefile
@@ -5,4 +5,4 @@ rgb.txt:
 	# xorg colors
 	# curl -o rgb.txt 'https://raw.githubusercontent.com/freedesktop/xorg-rgb/master/rgb.txt'
 	# vim colors
-	curl -o rgb.txt 'https://raw.githubusercontent.com/vim/vim/master/runtime/rgb.txt'
+	curl -o rgb.txt 'https://raw.githubusercontent.com/vim/vim/e30d10253f~/runtime/rgb.txt'


### PR DESCRIPTION
`rgb.txt` was made irrelevant in vim/vim@e30d10253fa634c4f60daa798d029245f4eed393 and eventually removed in
vim/vim@309ce251897512d42da2b0df0ff100dc303e688a therefore pin the URL to the parent commit which made it obsolete.