### PR TITLE
Include more colours in the greyscale ramp

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,13 +7,29 @@ function cell(r, g, b, cid, f) {
 }
 
 function setupTable(t, f) {
-  for (var tr, i = 16; i < 256; i++) {
+  let tr;
+  let i;
+  for (i = 16; i < 232; i++) {
     if ((i - 16) % 36 === 0) {
       tr = $('<tr>');
       t.append(tr);
     }
     tr.append(cell(...getIndexedColor(i), i, f));
   }
+  // include all the greys for the ramp
+  let colors = [];
+  for (i = 16; i < 232; i += 43) {
+    colors.push([i, getIndexedColor(i)]);
+  }
+  for (i = 232; i < 256; i++) {
+    colors.push([i, getIndexedColor(i)]);
+  }
+  colors.sort((a, b) => b[1][0] - a[1][0]);
+  tr = $('<tr>');
+  colors.forEach(c => {
+    tr.append(cell(...c[1], c[0], f));
+  });
+  t.append(tr);
 }
 
 $(() => {


### PR DESCRIPTION
The range 16-231 also included some greys so I extracted them into the ramp as well.

Before:

<img width="620" alt="image" src="https://user-images.githubusercontent.com/566719/188280084-3561603e-f6c7-4764-bcc9-63a79b57968f.png">

After:

<img width="618" alt="Screenshot 2022-09-03 at 17 38 16" src="https://user-images.githubusercontent.com/566719/188280121-8d370faf-b4d8-442a-ae50-545c50dec373.png">
